### PR TITLE
Set cursor shape to block, add `--export-ansi` CLI option and automat…

### DIFF
--- a/durdraw/durdraw_ui_curses.py
+++ b/durdraw/durdraw_ui_curses.py
@@ -30,6 +30,8 @@ class UserInterface():  # Separate view (curses) from this controller
     """ Draws user interface, has main UI loop. """
     #def __init__(self, stdscr, app):
     def __init__(self, app):
+        # Set cursor shape to block
+        sys.stdout.write(f"\x1b[1 q")
         self.opts = Options(width=app.width, height=app.height)
         self.appState = app # will be filled in by main() .. run-time app state stuff
         self.clipBoard = None   # frame object
@@ -2403,8 +2405,11 @@ class UserInterface():  # Separate view (curses) from this controller
         filename = str(self.stdscr.getstr().decode('utf-8'))
         curses.noecho()
         if filename.replace(' ', '') == '':
-            self.notify("File name cannot be empty.")
-            return False
+            if saveFormat == "dur":
+                filename = self.appState.curOpenFileName
+            else:
+                self.notify("File name cannot be empty.")
+                return False
         filename = os.path.expanduser(filename)
         # If file exists.. ask if it should overwrite.
         if os.path.exists(filename):

--- a/durdraw/main.py
+++ b/durdraw/main.py
@@ -67,6 +67,7 @@ def main():
     parser.add_argument("-V", "--version", help="Show version number and exit",
                     action="store_true")
     parser.add_argument("--debug", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--export-ansi", action="store_true", help="Export loaded art to an ANSI file and exit")
     args = parser.parse_args()
     if args.version:
         print(DUR_VER)
@@ -213,6 +214,10 @@ def main():
             ui.loadFromFile(movie, 'dur')
             ui.startPlaying()
             ui.stdscr.clear()
+        ui.verySafeQuit()
+    if args.export_ansi:
+        # Export ansi and exit
+        ui.saveAnsiFile(os.path.splitext(args.filename)[0] + ".ansi")
         ui.verySafeQuit()
     ui.refresh()
     ui.mainLoop()


### PR DESCRIPTION
…ically save as opened file name.