### PR TITLE
Bug fix for cursor landing in wrong spot in playback mode

### DIFF
--- a/durdraw/durdraw_ui_curses.py
+++ b/durdraw/durdraw_ui_curses.py
@@ -1013,11 +1013,11 @@ class UserInterface():  # Separate view (curses) from this controller
             # get keyboard input, returns -1 if none available
             self.move(self.xy[0], self.xy[1])
             self.refresh()
+            if self.appState.viewModeShowInfo: 
+                self.showFileInformation()
             if not self.appState.playOnlyMode:
                 self.drawStatusBar()
                 self.move(self.xy[0], self.xy[1] - 1)   # reposition cursor
-            if self.appState.viewModeShowInfo: 
-                self.showFileInformation()
             c = self.stdscr.getch()
             if c == 27:
                 self.metaKey = 1


### PR DESCRIPTION
Merging fix for 0.25.1 bug fix release.

This fixes an issue where if the file information is displaying in the sidebar, and the editor is in playback editing mode, the cursor can disappear from landing in the wrong spot.
