### PR TITLE
Added an instruction for Linux Terminal Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ The Linux Terminal users may need to configure the terminal to avoid key conflic
 
 - **GNOME Terminal**: **Click**: Menu -> Edit -> Preferences -> General, and **uncheck** the box: 
 
-  - Enable the menu accelerator key (F10 by default)
+  - [ ] Enable the menu accelerator key (F10 by default)
 
 - **Xfce4-Terminal**: **Click**: Menu -> Edit -> Preferences -> Advanced, and **check** the 2 boxes:
 
-  - Disable menu shortcut key (F10 by default)
-  - Disable help window shortcut key (F1 by default)
+  - [*] Disable menu shortcut key (F10 by default)
+  - [*] Disable help window shortcut key (F1 by default)
 
 
 ## GALLERY

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ To edit 16-color PC Scene (MS-DOS/CP437) ANSI art files in a Utf-8 terminal, use
     ./start-durdraw --16color
 ```
 
+The Linux Terminal users may need to disable the menu accelerator key to avoid key conflict:
+
+- Click: Menu -> Edit -> Preferences -> General
+- Then uncheck the box: [] Enable the menu accelerator key (F10 by default)
+
 
 ## GALLERY
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ The Linux Terminal users may need to configure the terminal to avoid key conflic
 
 - **Xfce4-Terminal**: **Click**: Menu -> Edit -> Preferences -> Advanced, and **check** the 2 boxes:
 
-  - [ ] Disable menu shortcut key (F10 by default)
-  - [ ] Disable help window shortcut key (F1 by default)
+  - [x] Disable menu shortcut key (F10 by default)
+  - [x] Disable help window shortcut key (F1 by default)
 
 
 ## GALLERY

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ The Linux Terminal users may need to configure the terminal to avoid key conflic
 
 - **Xfce4-Terminal**: **Click**: Menu -> Edit -> Preferences -> Advanced, and **check** the 2 boxes:
 
-  - [*] Disable menu shortcut key (F10 by default)
-  - [*] Disable help window shortcut key (F1 by default)
+  - [ ] Disable menu shortcut key (F10 by default)
+  - [ ] Disable help window shortcut key (F1 by default)
 
 
 ## GALLERY

--- a/README.md
+++ b/README.md
@@ -87,10 +87,16 @@ To edit 16-color PC Scene (MS-DOS/CP437) ANSI art files in a Utf-8 terminal, use
     ./start-durdraw --16color
 ```
 
-The Linux Terminal users may need to disable the menu accelerator key to avoid key conflict:
+The Linux Terminal users may need to configure the terminal to avoid key conflict:
 
-- **Click**: Menu -> Edit -> Preferences -> General
-- **Uncheck** the box: Enable the menu accelerator key (F10 by default)
+- **GNOME Terminal**: **Click**: Menu -> Edit -> Preferences -> General, and **uncheck** the box: 
+
+  - Enable the menu accelerator key (F10 by default)
+
+- **Xfce4-Terminal**: **Click**: Menu -> Edit -> Preferences -> Advanced, and **check** the 2 boxes:
+
+  - Disable menu shortcut key (F10 by default)
+  - Disable help window shortcut key (F1 by default)
 
 
 ## GALLERY

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ To edit 16-color PC Scene (MS-DOS/CP437) ANSI art files in a Utf-8 terminal, use
 
 The Linux Terminal users may need to disable the menu accelerator key to avoid key conflict:
 
-- Click: Menu -> Edit -> Preferences -> General
-- Then uncheck the box: [] Enable the menu accelerator key (F10 by default)
+- **Click**: Menu -> Edit -> Preferences -> General
+- **Uncheck** the box: Enable the menu accelerator key (F10 by default)
 
 
 ## GALLERY


### PR DESCRIPTION
For Linux Terminal Users, the F10 may be taken as the menu accelerator key by default.

Therefore, without configuring, durdraw cannot use F10 key, a conflict may occur. See the screenshot attached.


![screenshot](https://github.com/cmang/durdraw/assets/59274212/b09e41fd-d9d8-45be-9094-ba832f0b0a1f)


Just added an instruction to tell Linux Terminal users how to avoid this conflict.