### PR TITLE
README: Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,29 @@ color output, and other interesting features.
 Durdraw is heavily inspired by classic ANSI editing software for MS-DOS and
 Windows, such as TheDraw, Aciddraw and Pablodraw, but with a modern Unix twist.
 
+- [Durdraw](#durdraw)
+  - [OVERVIEW](#overview)
+  - [REQUIREMENTS](#requirements)
+  - [INSTALLATION](#installation)
+    - [Via OS Repositories](#via-os-repositories)
+    - [Via Source Repository](#via-source-repository)
+    - [Via pip](#via-pip)
+  - [RUNNING WITHOUT INSTALLING](#running-without-installing)
+  - [OPTIONAL INSTALLATION](#optional-installation)
+  - [GALLERY](#gallery)
+  - [COMMAND LINE USAGE](#command-line-usage)
+  - [INTERACTIVE USAGE/EDITING](#interactive-usageediting)
+  - [CONFIGURATION](#configuration)
+  - [DURFETCH](#durfetch)
+  - [FAQ](#faq)
+  - [LINKS, MEDIA AND THANKS](#links-media-and-thanks)
+  - [SUPPORT](#support)
+  - [COMMUNITY](#community)
+  - [CREDITS](#credits)
+  - [LEGAL](#legal)
+
+---
+
 ## REQUIREMENTS
 
 * Python 3 (3.10+ recommended)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Windows, such as TheDraw, Aciddraw and Pablodraw, but with a modern Unix twist.
 - [Durdraw](#durdraw)
   - [OVERVIEW](#overview)
   - [REQUIREMENTS](#requirements)
+    - [OPTIONAL REQUIREMENTS](#optional-requirements)
   - [INSTALLATION](#installation)
     - [Via OS Repositories](#via-os-repositories)
     - [Via Source Repository](#via-source-repository)
     - [Via pip](#via-pip)
   - [RUNNING WITHOUT INSTALLING](#running-without-installing)
-  - [OPTIONAL INSTALLATION](#optional-installation)
   - [GALLERY](#gallery)
   - [COMMAND LINE USAGE](#command-line-usage)
   - [INTERACTIVE USAGE/EDITING](#interactive-usageediting)
@@ -48,6 +48,17 @@ Windows, such as TheDraw, Aciddraw and Pablodraw, but with a modern Unix twist.
 
 * Python 3 (3.10+ recommended)
 * Linux, macOS, or other Unix-like System
+
+### OPTIONAL REQUIREMENTS
+
+1. `ansilove`
+
+    For PNG and animated GIF export, please install `ansilove` (https://ansilove.org/) and make sure it is is in your path.   
+    _PNG and GIF export only works in 16-color mode for now, and only with CP437 compatible charcters._
+
+3. `neofetch`
+
+    For [DURFETCH](#durfetch) support, please install `neofetch` and place it in your path.
 
 ## INSTALLATION
 
@@ -119,12 +130,6 @@ To look at some included example animations:
 ```shell
 ./start-durdraw -p examples/*.dur
 ```
-
-## OPTIONAL INSTALLATION
-
-For PNG and animated GIF export, please install Ansilove (https://ansilove.org/) and make sure it is is in your path. PNG and GIF export only work in 16-color mode for now, and only with CP437 compatible charcters. You also need the PIL python module.
-
-For Durfetch support, please install Neofetch and place it in your path.
 
 ## GALLERY
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ Windows, such as TheDraw, Aciddraw and Pablodraw, but with a modern Unix twist.
     - [Via OS Repositories](#via-os-repositories)
     - [Via Source Repository](#via-source-repository)
     - [Via pip](#via-pip)
-  - [Running Without Installing](#running-without-installing)
+    - [Running Without Installing](#running-without-installing)
   - [Gallery](#gallery)
-  - [Command Line Usage](#command-line-usage)
-  - [Interactive Usage/Editing](#interactive-usageediting)
-  - [Configuration](#configuration)
+  - [Usage](#usage)
+    - [Command Line](#command-line)
+    - [Interactive Usage/Editing](#interactive-usageediting)
+    - [Configuration](#configuration)
   - [Durfetch](#durfetch)
   - [FAQ](#faq)
   - [Links, Media \& Thanks](#links-media--thanks)
@@ -116,7 +117,7 @@ python3 -m pip install 'git+https://github.com/cmang/durdraw@0.28.0'
 python3 -m pip install 'git+https://github.com/cmang/durdraw@dev'
 ```
 
-## Running Without Installing
+### Running Without Installing
 
 You can run Durdraw with:
 
@@ -145,7 +146,9 @@ To look at some included example animations:
 ![cm-doge](https://user-images.githubusercontent.com/261501/210064365-e9303bee-7842-4068-b356-cd314341098b.gif)
 ![bsd-color-new](https://user-images.githubusercontent.com/261501/210064354-5c1c2adc-06a3-43c5-8e21-30b1a81db315.gif)
 
-## Command Line Usage
+## Usage
+
+### Command Line
 
 You can play a .dur file or series of .dur (or .ANS or .ASC) files with:
 
@@ -203,7 +206,7 @@ options:
 
 </pre>
 
-## Interactive Usage/Editing
+### Interactive Usage/Editing
 
 Use the arrow keys (or mouse) and other keys to edit, much like a text editor.
 
@@ -297,7 +300,7 @@ FG:██              (1/21)  [Dur..] <F1░F2▒F3▓F4█F5▀F6▄F7▌F8▐
     Paint (P). You can now use the mouse to paint with your custom brush.
 ```
 
-## Configuration
+### Configuration
 
 You can create a custom startup file where you can set a theme and other options.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Durdraw
 ![durdraw-0 28-demo](https://github.com/user-attachments/assets/3bdb0c46-7f21-4514-9b48-ac00ca62e68e)
 
 
-## OVERVIEW
+## Overview
 
 Durdraw is an ASCII, Unicode and ANSI art editor for UNIX-like systems (Linux,
 macOS, etc). It runs in modern Utf-8 terminals and supports frame-based
@@ -22,34 +22,34 @@ Durdraw is heavily inspired by classic ANSI editing software for MS-DOS and
 Windows, such as TheDraw, Aciddraw and Pablodraw, but with a modern Unix twist.
 
 - [Durdraw](#durdraw)
-  - [OVERVIEW](#overview)
-  - [REQUIREMENTS](#requirements)
-    - [OPTIONAL REQUIREMENTS](#optional-requirements)
-  - [INSTALLATION](#installation)
+  - [Overview](#overview)
+  - [Requirements](#requirements)
+    - [Optional Requirements](#optional-requirements)
+  - [Installation](#installation)
     - [Via OS Repositories](#via-os-repositories)
     - [Via Source Repository](#via-source-repository)
     - [Via pip](#via-pip)
-  - [RUNNING WITHOUT INSTALLING](#running-without-installing)
-  - [GALLERY](#gallery)
-  - [COMMAND LINE USAGE](#command-line-usage)
-  - [INTERACTIVE USAGE/EDITING](#interactive-usageediting)
-  - [CONFIGURATION](#configuration)
-  - [DURFETCH](#durfetch)
+  - [Running Without Installing](#running-without-installing)
+  - [Gallery](#gallery)
+  - [Command Line Usage](#command-line-usage)
+  - [Interactive Usage/Editing](#interactive-usageediting)
+  - [Configuration](#configuration)
+  - [Durfetch](#durfetch)
   - [FAQ](#faq)
-  - [LINKS, MEDIA AND THANKS](#links-media-and-thanks)
-  - [SUPPORT](#support)
-  - [COMMUNITY](#community)
-  - [CREDITS](#credits)
-  - [LEGAL](#legal)
+  - [Links, Media \& Thanks](#links-media--thanks)
+  - [Support](#support)
+  - [Community](#community)
+  - [Credits](#credits)
+  - [Legal](#legal)
 
 ---
 
-## REQUIREMENTS
+## Requirements
 
 * Python 3 (3.10+ recommended)
 * Linux, macOS, or other Unix-like System
 
-### OPTIONAL REQUIREMENTS
+### Optional Requirements
 
 1. `ansilove`
 
@@ -58,9 +58,9 @@ Windows, such as TheDraw, Aciddraw and Pablodraw, but with a modern Unix twist.
 
 3. `neofetch`
 
-    For [DURFETCH](#durfetch) support, please install `neofetch` and place it in your path.
+    For [Durfetch](#durfetch) support, please install `neofetch` and place it in your path.
 
-## INSTALLATION
+## Installation
 
 You can install durdraw via several methods:
 
@@ -68,9 +68,9 @@ You can install durdraw via several methods:
 - [Via Source Repository](#via-source-repository)
 - [Via pip](#via-pip)
 
-After installing, you should be able to run `durdraw`. Press `esc-h` for help, or try `durdraw --help` for command-line options.
+After installing, you should be able to run `durdraw`. Press `esc-h` for help, or try `durdraw --help` for [command-line options](#command-line-usage).
 
-_If you just want to run it without installing, see [RUNNING WITHOUT INSTALLING](#running-without-installing)_
+_If you just want to run it without installing, see [Running Without Installing](#running-without-installing)_
 
 ### Via OS Repositories
 
@@ -117,7 +117,7 @@ python3 -m pip install 'git+https://github.com/cmang/durdraw@0.28.0'
 python3 -m pip install 'git+https://github.com/cmang/durdraw@dev'
 ```
 
-## RUNNING WITHOUT INSTALLING
+## Running Without Installing
 
 You can run Durdraw with:
 
@@ -131,7 +131,7 @@ To look at some included example animations:
 ./start-durdraw -p examples/*.dur
 ```
 
-## GALLERY
+## Gallery
 
 [![Watch the Tutorial Part 1](https://github.com/cmang/durdraw/assets/261501/ca33c81b-0559-4fc7-a49b-a11768938d3d)](https://youtu.be/vWczO0Vd_54)
 
@@ -146,7 +146,7 @@ To look at some included example animations:
 ![cm-doge](https://user-images.githubusercontent.com/261501/210064365-e9303bee-7842-4068-b356-cd314341098b.gif)
 ![bsd-color-new](https://user-images.githubusercontent.com/261501/210064354-5c1c2adc-06a3-43c5-8e21-30b1a81db315.gif)
 
-## COMMAND LINE USAGE
+## Command Line Usage
 
 You can play a .dur file or series of .dur (or .ANS or .ASC) files with:
 
@@ -204,7 +204,7 @@ options:
 
 </pre>
 
-## INTERACTIVE USAGE/EDITING
+## Interactive Usage/Editing
 
 Use the arrow keys (or mouse) and other keys to edit, much like a text editor.
 
@@ -298,7 +298,7 @@ FG:██              (1/21)  [Dur..] <F1░F2▒F3▓F4█F5▀F6▄F7▌F8▐
     Paint (P). You can now use the mouse to paint with your custom brush.
 ```
 
-## CONFIGURATION
+## Configuration
 
 You can create a custom startup file where you can set a theme and other options.
 
@@ -397,7 +397,7 @@ menuTitleColor: the color of menu titles
 menuBorderColor: the color of the border around menus
 ```
 
-## DURFETCH
+## Durfetch
 
 Durfetch is a program which acts like a fetcher. It uses Neofetch to obtain system statistics and requires that Neofetch be found in the path. You can put keys in your .DUR files which durfetch will replace with values from Neofetch. You can also use built-in example animations.
 
@@ -489,7 +489,7 @@ A: You can use ESC-1 through ESC-0 as a replacement for F1-F10. Some terminals w
   - [x] Disable menu shortcut key (F10 by default)
   - [x] Disable help window shortcut key (F1 by default)
 
-## LINKS, MEDIA AND THANKS
+## Links, Media & Thanks
 
 Special thanks to the following individuals and organizations for featuring Durdraw in their content:
 
@@ -509,7 +509,7 @@ Harald Markus Wirth (hmw) has made a Web .Dur Player in JavaScript: https://hara
 
 If you write, podcast, vlog, or create content about Durdraw, or if you simply enjoy using it, I'd love to hear from you! Please reach out to me via the GitHub project page or at samfoster@gmail.com.
 
-## SUPPORT 
+## Support
 
 Your support means a lot to Durdraw! As a free and open-source project, your donations fuel my motivation to keep improving this software. Thank you for considering a contribution to help sustain and enhance this project.
 
@@ -527,7 +527,7 @@ Other ways to support Durdraw include reporting bugs, providing feedback, and co
 
 If you need assistance or have questions about Durdraw, feel free to reach out to us on GitHub. We're happy to help!
 
-## COMMUNITY
+## Community
 
 There are community discussions on Github, where people post art made with Durdraw. Check it out: https://github.com/cmang/durdraw/discussions
 
@@ -535,7 +535,7 @@ We also have a Discord server for Durdraw users. Join us: https://discord.gg/9Tr
 
 If you are feeling really old school, you can try the #durdraw IRC channel on irc.libera.chat.
 
-## CREDITS
+## Credits
 
 Developer: Sam Foster <samfoster@gmail.com>. For a full list of contributors, see the github page below.
 
@@ -545,7 +545,7 @@ Development: https://github.com/cmang/durdraw
 
 ANSI and ASCII artists: cmang, H7, LDA, HK
 
-## LEGAL
+## Legal
 
 Durdraw is Copyright (c) 2009-2024 Sam Foster <samfoster@gmail.com>. All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can install durdraw via several methods:
 
 After installing, you should be able to run `durdraw`. Press `esc-h` for help, or try `durdraw --help` for command-line options.
 
-_If you just want to run it without installing, scroll down to the next section._
+_If you just want to run it without installing, see [RUNNING WITHOUT INSTALLING](#running-without-installing)_
 
 ### Via OS Repositories
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Windows, such as TheDraw, Aciddraw and Pablodraw, but with a modern Unix twist.
 - [Durdraw](#durdraw)
   - [Overview](#overview)
   - [Requirements](#requirements)
-    - [Optional Requirements](#optional-requirements)
   - [Installation](#installation)
     - [Via OS Repositories](#via-os-repositories)
     - [Via Source Repository](#via-source-repository)
@@ -49,14 +48,14 @@ Windows, such as TheDraw, Aciddraw and Pablodraw, but with a modern Unix twist.
 * Python 3 (3.10+ recommended)
 * Linux, macOS, or other Unix-like System
 
-### Optional Requirements
+**Optional Requirements**
 
 1. `ansilove`
 
     For PNG and animated GIF export, please install `ansilove` (https://ansilove.org/) and make sure it is is in your path.   
     _PNG and GIF export only works in 16-color mode for now, and only with CP437 compatible charcters._
 
-3. `neofetch`
+2. `neofetch`
 
     For [Durfetch](#durfetch) support, please install `neofetch` and place it in your path.
 


### PR DESCRIPTION
## Context

This README could use a table of contents to allow easy/instant navigation to the relevant section.

## Changes

- added a table of contents
  - this is using the "markdown all-in-one" plugin for vscode, which I use pretty regularly for all my READMEs
- heading format and arrangement
  - title-case all headings. I'm not sure if this is going too far or altering the original ALL CAPS vibe of the headings, but I find title/camel case generally easier on the eyes
  - rearrange headings to be more hierarchical