### PR TITLE
use pickle for serialising undo frames

### DIFF
--- a/durdraw/durdraw_undo.py
+++ b/durdraw/durdraw_undo.py
@@ -1,4 +1,5 @@
 import pickle
+import tempfile
 
 class UndoManager():  # pass it a UserInterface object so Undo can tell UI
         # when to switch to another saved movie state.
@@ -14,6 +15,7 @@ class UndoManager():  # pass it a UserInterface object so Undo can tell UI
             self.appState = appState
             # AppState values passed to setHistorySize() below.
             self.push() # push initial state
+
         def push(self): # maybe should be called pushState or saveState?
             """ Take current movie, add to the end of a list of movie
                 objects - ie, push current state onto the undo stack. """
@@ -29,7 +31,13 @@ class UndoManager():  # pass it a UserInterface object so Undo can tell UI
             # ie we have redo states, remove all items after undoList[undoIndex]
             self.undoList = self.undoList[0:self.undoIndex]  # trim list
             # then add the new state to the end of the queue.
-            self.undoList.append(pickle.dumps(self.ui.mov))
+
+            # create a temporary file to store the pickled movie object
+            f = tempfile.TemporaryFile()
+            pickle.dump(self.ui.mov, f)
+            f.seek(0)
+            self.undoList.append(f)
+
             # last item added == at the end of the list, so..
             self.undoIndex = len(self.undoList) # point index to last item
 
@@ -47,7 +55,7 @@ class UndoManager():  # pass it a UserInterface object so Undo can tell UI
                 self.push()
                 self.undoIndex -= 1
             self.undoIndex -= 1
-            self.ui.mov = pickle.loads(self.undoList[self.undoIndex]) # set UI movie state
+            self.ui.mov = pickle.load(self.undoList[self.undoIndex]) # set UI movie state
             return True # succeeded
 
         def redo(self):

--- a/durdraw/durdraw_undo.py
+++ b/durdraw/durdraw_undo.py
@@ -56,13 +56,17 @@ class UndoManager():  # pass it a UserInterface object so Undo can tell UI
                 self.undoIndex -= 1
             self.undoIndex -= 1
             self.ui.mov = pickle.load(self.undoList[self.undoIndex]) # set UI movie state
+            self.undoList[self.undoIndex].seek(0)
             return True # succeeded
 
         def redo(self):
             if self.undoIndex < (len(self.undoList) -1): # we can redo
                 self.undoIndex += 1 # go to next redo state
                 self.modifications += 1
-                self.ui.mov = self.undoList[self.undoIndex]
+
+                self.ui.mov = pickle.load(self.undoList[self.undoIndex]) # set UI movie state
+                self.undoList[self.undoIndex].seek(0)
+
                 if self.appState.modified == False:
                     self.appState.modified = True
             else:

--- a/durdraw/durdraw_undo.py
+++ b/durdraw/durdraw_undo.py
@@ -1,4 +1,4 @@
-from copy import copy, deepcopy
+import pickle
 
 class UndoManager():  # pass it a UserInterface object so Undo can tell UI
         # when to switch to another saved movie state.
@@ -29,9 +29,10 @@ class UndoManager():  # pass it a UserInterface object so Undo can tell UI
             # ie we have redo states, remove all items after undoList[undoIndex]
             self.undoList = self.undoList[0:self.undoIndex]  # trim list
             # then add the new state to the end of the queue.
-            self.undoList.append(deepcopy(self.ui.mov))
+            self.undoList.append(pickle.dumps(self.ui.mov))
             # last item added == at the end of the list, so..
             self.undoIndex = len(self.undoList) # point index to last item
+
         def undo(self):
             if self.modifications > 1:
                 self.modifications = self.modifications - 1
@@ -46,8 +47,9 @@ class UndoManager():  # pass it a UserInterface object so Undo can tell UI
                 self.push()
                 self.undoIndex -= 1
             self.undoIndex -= 1
-            self.ui.mov = self.undoList[self.undoIndex] # set UI movie state
+            self.ui.mov = pickle.loads(self.undoList[self.undoIndex]) # set UI movie state
             return True # succeeded
+
         def redo(self):
             if self.undoIndex < (len(self.undoList) -1): # we can redo
                 self.undoIndex += 1 # go to next redo state


### PR DESCRIPTION
## Context

I found (hopefully) a quick win for the undo system

I tested this with `indyz-xmas` which is pretty laggy to edit and notice a definite improvement :tada: 

## Changes

- create a tempfile for each undo item (https://docs.python.org/3/library/tempfile.html)
- use `pickle.dump` and `pickle.load` to write/read undo frames via the tempfiles (https://docs.python.org/3/library/pickle.html#module-pickle)

## Results

e.g. on my computer

- deepcopy has
  - an average of ~0.075 seconds
  - an average undo of ~0.00004 seconds (as it should)
  - uses 438,924 kb for 100 undo frames
  - uses 39% CPU

- pickle with tempfile
  - average push of ~0.015 seconds
  - an average undo of ~0.015 seconds
  - uses 77,012 kb memory for 100 undo frames
  - uses 8% CPU

> _This change means that the limit on the undo buffer could possibly be removed entirely_