### PR TITLE
Logging fix duplicates

### DIFF
--- a/durdraw/log.py
+++ b/durdraw/log.py
@@ -100,6 +100,9 @@ def _getLogger(name: str, level: int = logging.CRITICAL, handlers: list = [], lo
     logger = logging.getLogger(f'{LOG_ROOT_NAME}.{name}')
     logger.setLevel(level)
 
+    if logger.hasHandlers():
+        logger.handlers.clear()
+
     # add the new handlers
     for handler in handlers:
         handler.setLevel(level)

--- a/durdraw/log.py
+++ b/durdraw/log.py
@@ -21,7 +21,7 @@ usage examples to log messages:
     # {"timestamp": "2024-12-09T15:05:43.904600", "msg": "This is an info message", "data": {"key": "value"}}
 '''
 
-from dataclasses import asdict, dataclass, is_dataclass, field
+from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
 import json
 import logging
@@ -118,28 +118,6 @@ def _getLogger(name: str, level: int = logging.CRITICAL, handlers: list = [], lo
         logger.handlers[0].setFormatter(LogFormatter(tz=tz))
 
     return logger
-
-
-@dataclass
-class Logger:
-    '''
-    A class to create a logger with custom handlers and a custom formatter.
-    Logger(name, level, handlers, print_stream, filepath)
-    '''
-    name: str
-    level: int = logging.CRITICAL
-    filepath: str = DEFAULT_LOG_FILEPATH
-    handlers: list = field(init=False, default_factory=list)
-
-    def __post_init__(self):
-        self.handlers.append(logging.FileHandler(self.filepath))
-
-    def getLogger(self) -> logging.Logger:
-        return _getLogger(self.name, self.level, handlers=self.handlers)
-
-    @property
-    def logger(self) -> logging.Logger:
-        return self.getLogger()
 
 
 def getLogger(

--- a/test/durdraw/test_log.py
+++ b/test/durdraw/test_log.py
@@ -7,10 +7,10 @@ import logging
 import os
 import time
 
-def init_test_logger(**kwargs):
+def init_test_logger(name='test_log', **kwargs):
     fake_stream = io.StringIO()
     logger = log._getLogger(
-        'test_log',
+        name,
         level='INFO',
         handlers=[logging.StreamHandler(fake_stream)],
         **kwargs
@@ -129,3 +129,64 @@ class TestLog:
             'name': 'durdraw.test_log',
             'data': {},
         }
+
+    def test_multiple_loggers(self):
+        if os.path.exists('test_log.log'):
+            os.remove('test_log.log')
+
+        logger1 = log.getLogger('test_log', level='INFO', filepath='test_log.log', override=True)
+        logger1.info('Hello, world!')
+        logger2 = log.getLogger('test_log2', level='INFO', filepath='test_log.log', override=False)
+        logger2.info('Hello, world!')
+
+        with open('test_log.log', 'r') as file:
+            results = list(map(json.loads, file))
+        for result in results:
+            del result['timestamp']
+        os.remove('test_log.log')
+
+        assert results == [
+            {
+                'msg': 'Hello, world!',
+                'level': 'INFO',
+                'name': 'durdraw.test_log',
+                'data': {},
+            },
+            {
+                'msg': 'Hello, world!',
+                'level': 'INFO',
+                'name': 'durdraw.test_log2',
+                'data': {},
+            },
+        ]
+
+
+    def test_reuse_loggers(self):
+        if os.path.exists('test_log.log'):
+            os.remove('test_log.log')
+
+        logger1 = log.getLogger('test_log', level='INFO', filepath='test_log.log', override=True)
+        logger2 = log.getLogger('test_log', level='INFO', filepath='test_log.log', override=False)
+        logger2.info('Hello, world!')
+        logger1.info('Hello, world!')
+
+        with open('test_log.log', 'r') as file:
+            results = list(map(json.loads, file))
+        for result in results:
+            del result['timestamp']
+        os.remove('test_log.log')
+
+        assert results == [
+            {
+                'msg': 'Hello, world!',
+                'level': 'INFO',
+                'name': 'durdraw.test_log',
+                'data': {},
+            },
+            {
+                'msg': 'Hello, world!',
+                'level': 'INFO',
+                'name': 'durdraw.test_log',
+                'data': {},
+            },
+        ]

--- a/test/durdraw/test_log.py
+++ b/test/durdraw/test_log.py
@@ -131,12 +131,15 @@ class TestLog:
         }
 
     def test_multiple_loggers(self):
+        '''Test that child loggers with different names don't produce duplicate logs'''
+
         if os.path.exists('test_log.log'):
             os.remove('test_log.log')
 
         logger1 = log.getLogger('test_log', level='INFO', filepath='test_log.log', override=True)
-        logger1.info('Hello, world!')
         logger2 = log.getLogger('test_log2', level='INFO', filepath='test_log.log', override=False)
+
+        logger1.info('Hello, world!')
         logger2.info('Hello, world!')
 
         with open('test_log.log', 'r') as file:
@@ -160,15 +163,17 @@ class TestLog:
             },
         ]
 
-
     def test_reuse_loggers(self):
+        '''Test that child loggers with the same name don't produce duplicate logs'''
+
         if os.path.exists('test_log.log'):
             os.remove('test_log.log')
 
         logger1 = log.getLogger('test_log', level='INFO', filepath='test_log.log', override=True)
         logger2 = log.getLogger('test_log', level='INFO', filepath='test_log.log', override=False)
-        logger2.info('Hello, world!')
+
         logger1.info('Hello, world!')
+        logger2.info('Hello, world!')
 
         with open('test_log.log', 'r') as file:
             results = list(map(json.loads, file))


### PR DESCRIPTION
## Context

Oh gosh, my first regression 🙈 

When viewing the new logger output I noticed that there were quite a few lines that were exact duplicates down to the microsecond, which would usually be impossible

Upon further inspection, I realised that this is due to successive/repeated calls to instantiate a logger of the same name (e.g. for each `Frame`, calling `getLogger` for a logger of the name `durdraw.frame`)

This ends up accumulating FileHandlers, as each time this happens the exact same logger object is fetched and has a handler added to it 💥 

---

## Changes

- I added tests for this case
- The simplest approach is to clear any existing handlers from the logger, before adding the new handlers
