### PR TITLE
use app.charEncoding when running --export-ansi

### DIFF
--- a/durdraw/main.py
+++ b/durdraw/main.py
@@ -267,7 +267,7 @@ def main(fetch_args=None):
         ui.verySafeQuit()
     if args.export_ansi:
         # Export ansi and exit
-        ui.saveAnsiFile(os.path.splitext(args.filename)[0] + ".ansi")
+        ui.saveAnsiFile(os.path.splitext(args.filename)[0] + ".ansi", encoding=app.charEncoding)
         ui.verySafeQuit()
     ui.refresh()
     ui.mainLoop()


### PR DESCRIPTION
I found that durdraw crashes when I run it with `--export-ansi` to convert a file to ANSI/utf-8 format

This happens when durdraw tries to use "default" as the default encoding:

```
Traceback (most recent call last):
File "/home/freman/dev/durdraw/./start-durdraw", line 11, in <module>
    main.main()
File "/home/freman/dev/durdraw/durdraw/main.py", line 270, in main
    ui.saveAnsiFile(os.path.splitext(args.filename)[0] + ".ansi")
File "/home/freman/dev/durdraw/durdraw/durdraw_ui_curses.py", line 5954, in saveAnsiFile
    char.encode(encoding)
LookupError: unknown encoding: default
```

## Changes

- pass `app.charEncoding` to the `saveAnsiFile` function, as it's been parsed & defined further up in `main.py`