### PR TITLE
speed up parsing

### DIFF
--- a/durdraw/durdraw_ansiparse.py
+++ b/durdraw/durdraw_ansiparse.py
@@ -9,20 +9,23 @@
 # A code looks like this: ^[1;32m for bold color 32. ^[0m for reset.
 # ^[0;4;3;42m for reset (0), underline (4), italic (3), background color (42).
 # We have a state machine that has attributes. Color, bold, underline, italic, etc.
-# 
-# References: 
+#
+# References:
 # Escape code bible: https://en.wikipedia.org/wiki/ANSI_escape_code
 # ANSI Sauce (metadata) spec: https://www.acid.org/info/sauce/sauce.htm
 
 
 import sys
 import struct
-import re
+from itertools import count
 import pdb
 import durdraw.durdraw_movie as durmovie
 import durdraw.durdraw_color_curses as dur_ansilib
 import durdraw.durdraw_sauce as dursauce
 import durdraw.plugins.convert_charset as durchar
+import durdraw.log as log
+
+LOGGER = log.getLogger('ansiparse')
 
 def ansi_color_to_durcolor(ansiColor):
     colorName = ansi_color_to_durcolor_table[ansiColor]
@@ -77,10 +80,19 @@ def get_width_and_height_of_ansi_blob(text, width=80):
     line_num = 0
     max_col = 0
     while i < len(text):
+        if i % 10_000 == 0:
+            LOGGER.debug('scanning', {'i': i, 'total': len(text), 'pct': round(i / len(text) * 100, 2)})
         # If there's an escape code, extract data from it
         if text[i:i + 2] == '\x1B[':    # Match ^[
-            match = re.search('[a-zA-Z]', text[i:]) # match any control code 
-            end_index = match.start() + i   # where the code ends
+            match = None
+            for j in count(i+1):
+                if text[j].isalpha():
+                    match = j
+                    break
+            if not match:
+                i += 1 # move on to next byte
+                continue
+            end_index = match   # where the code ends
             if text[end_index] == 'A':      # Move the cursor up X spaces
                 escape_sequence = text[i + 2:end_index]
                 if len(escape_sequence) == 0:
@@ -232,18 +244,27 @@ def parse_ansi_escape_codes(text, filename = None, appState=None, caller=None, c
     max_col = 0
     default_fg_color = appState.defaultFgColor
     default_bg_color = appState.defaultBgColor
-    fg_color = default_fg_color 
-    bg_color = default_bg_color 
+    fg_color = default_fg_color
+    bg_color = default_bg_color
     bold = False
     saved_col_num = 0
     saved_line_num = 0
     saved_byte_location = 0
     parse_error = False
     while i < len(text):
+        if i % 10_000 == 0:
+            LOGGER.debug('parsing', {'i': i, 'total': len(text), 'pct': round(i / len(text) * 100, 2)})
         # If there's an escape code, extract data from it
         if text[i:i + 2] == '\x1B[':    # Match ^[[
-            match = re.search('[a-zA-Z]', text[i:]) # match any control code 
-            end_index = match.start() + i   # where the code ends
+            match = None
+            for j in count(i+1):
+                if text[j].isalpha():
+                    match = j
+                    break
+            if not match:
+                i += 1 # move on to next byte
+                continue
+            end_index = match   # where the code ends
             if text[end_index] == 'm':      # Color/SGR control code
                 escape_sequence = text[i + 2:end_index]
                 escape_codes = escape_sequence.split(';')

--- a/durdraw/durdraw_ansiparse.py
+++ b/durdraw/durdraw_ansiparse.py
@@ -73,6 +73,12 @@ color_name_to_durcolor_table = {
     'White': 00
 }
 
+def find_next_alpha(text, i):
+    for j in count(i):
+        if text[j].isalpha():
+            return j
+    return None
+
 
 def get_width_and_height_of_ansi_blob(text, width=80):
     i = 0   # index into the file blob
@@ -84,11 +90,7 @@ def get_width_and_height_of_ansi_blob(text, width=80):
             LOGGER.debug('scanning', {'i': i, 'total': len(text), 'pct': round(i / len(text) * 100, 2)})
         # If there's an escape code, extract data from it
         if text[i:i + 2] == '\x1B[':    # Match ^[
-            match = None
-            for j in count(i+1):
-                if text[j].isalpha():
-                    match = j
-                    break
+            match = find_next_alpha(text, i+1)
             if not match:
                 i += 1 # move on to next byte
                 continue
@@ -256,11 +258,7 @@ def parse_ansi_escape_codes(text, filename = None, appState=None, caller=None, c
             LOGGER.debug('parsing', {'i': i, 'total': len(text), 'pct': round(i / len(text) * 100, 2)})
         # If there's an escape code, extract data from it
         if text[i:i + 2] == '\x1B[':    # Match ^[[
-            match = None
-            for j in count(i+1):
-                if text[j].isalpha():
-                    match = j
-                    break
+            match = find_next_alpha(text, i+1)
             if not match:
                 i += 1 # move on to next byte
                 continue

--- a/durdraw/durdraw_ansiparse.py
+++ b/durdraw/durdraw_ansiparse.py
@@ -25,7 +25,7 @@ import durdraw.durdraw_sauce as dursauce
 import durdraw.plugins.convert_charset as durchar
 import durdraw.log as log
 
-LOGGER = log.getLogger('ansiparse')
+LOGGER = log.getLogger('ansiparse', level='DEBUG', override=True)
 
 def ansi_color_to_durcolor(ansiColor):
     colorName = ansi_color_to_durcolor_table[ansiColor]

--- a/durdraw/durdraw_ui_curses.py
+++ b/durdraw/durdraw_ui_curses.py
@@ -5927,6 +5927,8 @@ class UserInterface():  # Separate view (curses) from this controller
             firstLineNum = 0    # also don't crop leading blank lines. rude
         error_encoding = False
         for lineNum in range(firstLineNum, lastLineNum):  # y == lines
+            if lineNum % 10_000 == 0:
+                self.log.debug('writing ansi', {'lineNum': lineNum, 'total': lastLineNum, 'pct': round((lineNum/lastLineNum)*100, 2)})
             for colNum in range(firstColNum, lastColNum):
                 char = self.mov.currentFrame.content[lineNum][colNum]
                 color = self.mov.currentFrame.newColorMap[lineNum][colNum]


### PR DESCRIPTION
## Context

When testing large ansi files I found that they can take a while to load. After reading ansiparser, the main culprit of the slow parsing is the use of the regex to detect alpha characters. The python standard lib has a `str.isalpha` method that works well and is much faster.

I did a quick demo in ipython

```python
In [1]: import re

In [2]: s = 'A'

In [3]: %timeit re.search('[a-zA-Z]', s)
316 ns ± 12 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [4]: %timeit s.isalpha()
11.8 ns ± 0.0565 ns per loop (mean ± std. dev. of 7 runs, 100,000,000 loops each)
```

## Changes

- Convert the regex search into a for loop, calling `isalpha()` on each char

## Effect

On my PC, this reduces the time to load `Blocktronics-WTF4_Megajoint.ans` from **44 seconds > 2.5 seconds**

As far as I can see, the behaviour between this version and the existing one is identical and doesn't produce any different results that I've seen so far.