### PR TITLE
Speed up writing

### DIFF
--- a/durdraw/durdraw_ansiparse.py
+++ b/durdraw/durdraw_ansiparse.py
@@ -86,8 +86,8 @@ def get_width_and_height_of_ansi_blob(text, width=80):
     line_num = 0
     max_col = 0
     while i < len(text):
-        if i % 10_000 == 0:
-            LOGGER.debug('scanning', {'i': i, 'total': len(text), 'pct': round(i / len(text) * 100, 2)})
+        if i % 10_000 == 0 or i+1 == len(text):
+            LOGGER.debug('scanning', {'i': i+1, 'total': len(text), 'pct': round((i+1)/len(text)*100, 2)})
         # If there's an escape code, extract data from it
         if text[i:i + 2] == '\x1B[':    # Match ^[
             match = find_next_alpha(text, i+1)
@@ -254,8 +254,8 @@ def parse_ansi_escape_codes(text, filename = None, appState=None, caller=None, c
     saved_byte_location = 0
     parse_error = False
     while i < len(text):
-        if i % 10_000 == 0:
-            LOGGER.debug('parsing', {'i': i, 'total': len(text), 'pct': round(i / len(text) * 100, 2)})
+        if i % 10_000 == 0 or i+1 == len(text):
+            LOGGER.debug('parsing', {'i': i+1, 'total': len(text), 'pct': round((i+1)/len(text)*100, 2)})
         # If there's an escape code, extract data from it
         if text[i:i + 2] == '\x1B[':    # Match ^[[
             match = find_next_alpha(text, i+1)

--- a/durdraw/durdraw_color_curses.py
+++ b/durdraw/durdraw_color_curses.py
@@ -276,13 +276,12 @@ class AnsiArtStuff():
             5:"43", 6:"42", 7:"41", 8:"40", 0:"40"
         }
 
+    @lru_cache(maxsize=1024)
     def getColorCode24k(r, g, b):
         """ r, g and b must be numbers between 0-255 """
-        code = '\033[38;2;'
-        code += str(r) + ';' + str(g) + ';' + str(b)
-        code += 'm'
-        return code
+        return f'\033[38;2;{r};{g};{b}m'
 
+    @lru_cache(maxsize=1024)
     def getColorCodeIrc(self, fg, bg):
         """ Return a string containing the IRC color code to color the next
         character, for given fg/bg """
@@ -301,6 +300,7 @@ class AnsiArtStuff():
 
         return f'\x03{fg:02d},{bg:02d}'
 
+    @lru_cache(maxsize=1024)
     def getColorCode256(self, fg, bg):
         """ Return a string containing 256-color mode ANSI escape code for
         given fg/bg """

--- a/durdraw/durdraw_color_curses.py
+++ b/durdraw/durdraw_color_curses.py
@@ -311,7 +311,7 @@ class AnsiArtStuff():
     @lru_cache(maxsize=1024)
     def getColorCode(self, fg, bg):
         """ returns a string containing ANSI escape code for given fg/bg  """
-        return f'\033[38;5;{self.escapeFgMap[fg]};48;5;{self.escapeBgMap[bg]}m'
+        return f'\033[{self.escapeFgMap[fg]};{self.escapeBgMap[bg]}m'
 
     def codePage437(self):
         pass

--- a/durdraw/durdraw_color_curses.py
+++ b/durdraw/durdraw_color_curses.py
@@ -1,6 +1,7 @@
 import curses
 import time
 import pdb
+from functools import lru_cache
 
 legacy_256_to_256 = {   # used when loading an old 256 color file in 256 color mode
     #0: 7, # white
@@ -298,39 +299,19 @@ class AnsiArtStuff():
         #    fg = color_256_to_mirc_16[fg]
         #    bg = color_256_to_mirc_16[bg]
 
-        bg = 1
-
-        # build the code
-        code = '\x03'
-        #code = code + str(fg)
-        code = code + f'{fg:02d}'
-        code = code + ','
-        #code = code + str(bg)
-        code = code + f'{bg:02d}'
-        # code = code + '\x03'
-        return code
+        return f'\x03{fg:02d},{bg:02d}'
 
     def getColorCode256(self, fg, bg):
         """ Return a string containing 256-color mode ANSI escape code for
         given fg/bg """
         if fg <= 16 and fg > 0:
             fg = color_256_to_ansi_16[fg]
-        code = '\033[38;5;'    # begin escape sequence
-        code = code + str(fg)
-        code = code + ';'
-        code = code + '48;5;'
-        code = code + str(bg)
-        #code = code + str('0')
-        code = code + 'm'
-        return code
+        return f'\033[38;5;{fg};48;5;{bg}m'
 
+    @lru_cache(maxsize=1024)
     def getColorCode(self, fg, bg):
         """ returns a string containing ANSI escape code for given fg/bg  """
-        escape = '\033['    # begin escape sequence
-        escape = escape + self.escapeFgMap[fg] + ';'  # set fg color
-        escape = escape + self.escapeBgMap[bg]  # set bg color
-        escape = escape + "m"   # m = set graphics mode command
-        return escape
+        return f'\033[38;5;{self.escapeFgMap[fg]};48;5;{self.escapeBgMap[bg]}m'
 
     def codePage437(self):
         pass

--- a/durdraw/durdraw_ui_curses.py
+++ b/durdraw/durdraw_ui_curses.py
@@ -5914,7 +5914,7 @@ class UserInterface():  # Separate view (curses) from this controller
         except:
             self.notify("Could not open file for writing. (Press any key to continue)", pause=True)
             return False
-        string = ''
+        string = []
         if not lastLineNum: # if we weren't told what lastLineNum is...
             # find it (last line we should save)
             lastLineNum = self.findFrameLastLine(self.mov.currentFrame)
@@ -5927,8 +5927,8 @@ class UserInterface():  # Separate view (curses) from this controller
             firstLineNum = 0    # also don't crop leading blank lines. rude
         error_encoding = False
         for lineNum in range(firstLineNum, lastLineNum):  # y == lines
-            if lineNum % 10_000 == 0:
-                self.log.debug('writing ansi', {'lineNum': lineNum, 'total': lastLineNum, 'pct': round((lineNum/lastLineNum)*100, 2)})
+            if lineNum % 1000 == 0:
+                self.log.debug('writing ansi', {'lineNum': lineNum, 'total': lastLineNum, 'pct': round((lineNum/lastLineNum)*100, 2), 'colorMode': self.appState.colorMode})
             for colNum in range(firstColNum, lastColNum):
                 char = self.mov.currentFrame.content[lineNum][colNum]
                 color = self.mov.currentFrame.newColorMap[lineNum][colNum]
@@ -5962,15 +5962,14 @@ class UserInterface():  # Separate view (curses) from this controller
                     break
                 # If we don't have extended ncurses 6 color pairs,
                 # we don't have background colors.. so write the background as black/0
-                string = string + colorCode + char
+                string.append(colorCode + char)
             if ircColors:
-                string = string + '\n'
+                string.append('\n')
             else:
-                #string = string + '\r\n'
-                string = string + '\n'
+                string.append('\n')
         if not error_encoding:
             try:
-                f.write(string)
+                f.write(''.join(string))
                 saved = True
             except UnicodeEncodeError as encodeError:
                 self.notify("Error: Some characters were not compatible with this encoding. File not saved.", pause=True)
@@ -5978,11 +5977,7 @@ class UserInterface():  # Separate view (curses) from this controller
                 saved = False
                 #f.close()
                 #return False
-        if ircColors:
-            string2 = string + '\n'
-        else:
-            f.write('\033[0m') # color attributes off
-            string2 = string + '\r\n'   # final CR+LF (DOS style newlines)
+        f.write('\033[0m') # color attributes off
         f.close()
         #return True
         return saved

--- a/durdraw/durdraw_ui_curses.py
+++ b/durdraw/durdraw_ui_curses.py
@@ -5927,8 +5927,11 @@ class UserInterface():  # Separate view (curses) from this controller
             firstLineNum = 0    # also don't crop leading blank lines. rude
         error_encoding = False
         for lineNum in range(firstLineNum, lastLineNum):  # y == lines
-            if lineNum % 1000 == 0:
-                self.log.debug('writing ansi', {'lineNum': lineNum, 'total': lastLineNum, 'pct': round((lineNum/lastLineNum)*100, 2), 'colorMode': self.appState.colorMode})
+            if lineNum % 1000 == 0 or lineNum == lastLineNum-1:
+                self.log.debug(
+                    'writing ansi',
+                    {'lineNum': lineNum+1, 'total': lastLineNum, 'pct': round(((lineNum+1)/lastLineNum)*100, 2), 'colorMode': self.appState.colorMode}
+                )
             for colNum in range(firstColNum, lastColNum):
                 char = self.mov.currentFrame.content[lineNum][colNum]
                 color = self.mov.currentFrame.newColorMap[lineNum][colNum]


### PR DESCRIPTION
> [!NOTE]
> TL;DR, this reduces the time to write goto80-goto20.ans from `158 seconds > 0.06 seconds`
>
> Run this to test:
> ```
> wget https://16colo.rs/pack/impure77/raw/goto80-goto20.ans
> ./start-durdraw --export-ansi goto80-goto20.ans
> ```

## Changes

While looking into the parsing, I was curious about the writing and took a look there too. This time, the culprit is mainly from the string appending that happens many times over the loop.

1. Build up an array instead of a string and join it when writing
2. Use functools cache to memoize colour codes
3. Use an f-string instead of string appends to generate colour codes

## Side notes

### str.translate

In future, it could even be faster to use `str.translate` to translate colour codes in a large string all at once - I have found (in my experience) this function to be the fastest way to do string replacements https://docs.python.org/3/library/stdtypes.html#str.translate

### itertools "sliding_window"

There is a section of the wonderful itertools module that includes "recipes" - demonstrations of what's possible by combining the itertools standard functions. It lists one called "sliding window" that I think could be useful for parsing https://docs.python.org/3/library/itertools.html#itertools-recipes (search for "sliding_window")