### PR TITLE
Fix durview 16colors crash

### DIFF
--- a/durdraw/durdraw_ui_curses.py
+++ b/durdraw/durdraw_ui_curses.py
@@ -4516,19 +4516,23 @@ class UserInterface():  # Separate view (curses) from this controller
             if self.selected_item_number > len(file_list) - 1:
                 self.selected_item_number = 0
 
+            self.log.debug('selected item number', {'selected_item_number': self.selected_item_number, 'n_files': len(file_list)})
+
             #if not self.appState.sixteenc_browsing:
             #    try:
             #        filename = file_list[self.selected_item_number]
             #    except:
             #        pdb.set_trace()
-            filename = file_list[self.selected_item_number]
+            filename = None
+            if len(file_list) > 0:
+                filename = file_list[self.selected_item_number]
 
-            if self.appState.sixteenc_browsing:
+            if self.appState.sixteenc_browsing or filename is None:
                 full_path = ''
             else:
                 full_path = f"{current_directory}/{file_list[self.selected_item_number]}"
                 
-            if filename not in folders:
+            if filename not in folders and filename is not None :
                 # read sauce, if available
                 #file_sauce = dursauce.SauceParser(full_path)
                 file_sauce = dursauce.SauceParser()
@@ -4550,7 +4554,7 @@ class UserInterface():  # Separate view (curses) from this controller
                 #sauce_width = file_sauce.width
                 #sauce_height = file_sauce.height
 
-            if self.appState.sixteenc_browsing:
+            if self.appState.sixteenc_browsing or filename is None:
                 file_size = None
                 file_modtime_string = ""
             else:

--- a/durdraw/durfetch.py
+++ b/durdraw/durfetch.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import random
 
+from durdraw import log
 import durdraw.main as durdraw_main
 import durdraw.neofetcher as neofetcher
 from durdraw.durdraw_version import DUR_VER
@@ -66,6 +67,7 @@ def auto_load_file(neofetch_data, rand=False, fake_os=None):
         files = ['linux-fire.durf', 'linux-tux.durf']
     return random.choice(files)
 
+@log.log_on_crash
 def main():
 
     epilog_text = make_epilog()

--- a/durdraw/durview.py
+++ b/durdraw/durview.py
@@ -9,11 +9,13 @@ import sys
 import time
 import pathlib
 
+from durdraw import log
 from durdraw.durdraw_appstate import AppState
 from durdraw.durdraw_ui_curses import UserInterface as UI_Curses
 from durdraw.durdraw_options import Options
 import durdraw.help
 
+@log.log_on_crash
 def main(fetch_args=None):
     DURVIEW_VER = "0.1.0"
     DUR_FILE_VER = 7

--- a/durdraw/log.py
+++ b/durdraw/log.py
@@ -23,6 +23,7 @@ usage examples to log messages:
 
 from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
+from functools import wraps
 import json
 import logging
 
@@ -157,3 +158,23 @@ def getLogger(
         local_tz=CURRENT_LOG_TZ,
     )
 
+def log_on_crash(func):
+    '''
+    This is a decorator that can be used to log any exceptions that occur in a function.
+    This is mainly intended to wrap around the main() functions/entrypoints to durdraw,
+    so that any exceptions that occur can be logged to a file for debugging or support.
+    '''
+    logger = getLogger('crash', level='ERROR')
+    @wraps(func)
+    def inner(*args, **kwargs):
+        # run the function, return the result, and log any exceptions
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            logger.exception(
+                'durview crashed',
+                {'class': e.__class__.__name__, 'message': str(e)},
+                exc_info=True,
+            )
+            raise e
+    return inner

--- a/durdraw/main.py
+++ b/durdraw/main.py
@@ -9,6 +9,7 @@ import sys
 import time
 import pathlib
 
+from durdraw import log
 from durdraw.durdraw_appstate import AppState
 from durdraw.durdraw_ui_curses import UserInterface as UI_Curses
 from durdraw.durdraw_options import Options
@@ -27,6 +28,7 @@ class ArgumentChecker:
         else:
             raise argparse.ArgumentTypeError("Undo size must be between 1 and 1000.")
 
+@log.log_on_crash
 def main(fetch_args=None):
     DUR_FILE_VER = 7
     DEBUG_MODE = False # debug = makes debug_write available, sends verbose notifications
@@ -274,5 +276,3 @@ def main(fetch_args=None):
 
 if __name__ == "__main__":
     main()
-
-


### PR DESCRIPTION
This attempts to fix the release-blocking bug mentioned in https://github.com/cmang/durdraw/discussions/91

Essentially, the `file_list` is empty after deselecting all options, so I added a default value and some checks for `filename` which seem to fix the issue. I'm not very familiar with this part of the interface though so I'm hoping I didn't miss anything!