### PR TITLE
Support NixOS with nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,46 @@ python3 -m pip install 'git+https://github.com/cmang/durdraw@0.28.0'
 python3 -m pip install 'git+https://github.com/cmang/durdraw@dev'
 ```
 
+### Via Nix Flakes
+
+If you're using Nix with flakes enabled, you can install Durdraw in several ways:
+
+1. Run directly using `nix run`:
+
+```shell
+nix run github:cmang/durdraw
+```
+
+2. Add to your NixOS configuration:
+
+```nix
+{
+  inputs = {
+    durdraw.url = "github:cmang/durdraw";
+  };
+
+  outputs = { self, durdraw, ... }: {
+    # For your system configuration:
+    environment.systemPackages = [
+      durdraw.packages.${system}.default
+    ];
+
+    # Or for your home-manager configuration:
+    home.packages = [
+      durdraw.packages.${system}.default
+    ];
+  };
+}
+```
+
+3. For development, you can enter a development shell with:
+
+```shell
+nix develop github:cmang/durdraw
+```
+
+The Nix package includes all required dependencies including `neofetch` and `ansilove` for full functionality.
+
 ### Running Without Installing
 
 You can run Durdraw with:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1749143949,
+        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "Durdraw: ASCII, Unicode and ANSI art editor";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { nixpkgs, self, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      python = pkgs.python3;
+      pythonPackages = python.pkgs;
+      projectData = builtins.fromTOML (builtins.readFile ./pyproject.toml);
+    in
+    {
+      packages.${system}.default = pythonPackages.buildPythonApplication {
+        pname = projectData.project.name;
+        version = projectData.project.version;
+        src = ./.;
+        pyproject = true;
+        nativeBuildInputs = [
+          pythonPackages.setuptools
+          pythonPackages.wheel
+        ];
+        buildInputs = [
+          pkgs.neofetch
+          pkgs.ansilove
+        ];
+        doCheck = false;
+      };
+
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = [
+          python
+          pythonPackages.pip
+          pythonPackages.setuptools
+          pythonPackages.wheel
+          pythonPackages.pytest
+          pkgs.neofetch
+          pkgs.ansilove
+          self.packages.${system}.default
+        ];
+      };
+    };
+}


### PR DESCRIPTION
This pull request adds support for installing and developing Durdraw using Nix Flakes, introducing a `flake.nix` file and updating the installation instructions in the `README.md`. 

### Nix Flakes Support

* **Installation instructions in `README.md`:** Added a new section describing how to install Durdraw using Nix Flakes, including options for running directly with `nix run`, adding to NixOS or home-manager configurations, and entering a development shell.
* **New `flake.nix` file:** Introduced a `flake.nix` file to define the Nix Flakes configuration for Durdraw. It includes package definitions, system configurations, and a development shell setup with all required dependencies such as `neofetch` and `ansilove`.