### PR TITLE
fix: Fix assorted codespell typos in docs and parsing utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Durdraw
                   __                __
                 _|  |__ __ _____ __|  |_____ _____ __ __ __
                / _  |  |  |   __|  _  |   __|  _  |  |  |  |\
-              /_____|_____|__|__|_____|__|___\____|________| | 
+              /_____|_____|__|__|_____|__|___\____|________| |
               \_____________________________________________\|  v 0.29.0
 
 ![durdraw-0 28-demo](https://github.com/user-attachments/assets/3bdb0c46-7f21-4514-9b48-ac00ca62e68e)
@@ -44,7 +44,7 @@ Windows, such as TheDraw, Aciddraw and Pablodraw, but with a modern Unix twist.
 
 1. `ansilove`
 
-    For PNG and animated GIF export, please install `ansilove` (https://ansilove.org/) and make sure it is is in your path.   
+    For PNG and animated GIF export, please install `ansilove` (https://ansilove.org/) and make sure it is in your path.
     _PNG and GIF export only works in 16-color mode for now, and only with CP437 compatible characters._
 
 2. `neofetch`
@@ -411,7 +411,7 @@ menuBorderColor: 24
 
 #### Custom Character Sets
 
-You can create custom character set files and place them in the ~/.durdraw/charsets folder. Character set files must have the file nme extension .ini. Durdraw will automatically scan for these files and include them in the list of character sets (esc-S).
+You can create custom character set files and place them in the ~/.durdraw/charsets folder. Character set files must have the file name extension .ini. Durdraw will automatically scan for these files and include them in the list of character sets (esc-S).
 
 An example character set file is provided in example-charset.ini:
 
@@ -561,7 +561,7 @@ A: Look in your terminal setting for "Use bright colors for bold," or a similarl
 #### Q: Some or all of the F1-F10 keys do not work for me! What can I do?
 A: You can use ESC-1 through ESC-0 as a replacement for F1-F10. Some terminals will map this to Alt-1 through Alt-0. You can also use the following settings in some terminals to enable the F1-F10 keys:
 
-- **GNOME Terminal**: **Click**: Menu -> Edit -> Preferences -> General, and **uncheck** the box: 
+- **GNOME Terminal**: **Click**: Menu -> Edit -> Preferences -> General, and **uncheck** the box:
 
   - [ ] Enable the menu accelerator key (F10 by default)
 
@@ -624,7 +624,7 @@ If you are feeling really old school, you can try the #durdraw IRC channel on ir
 Durdraw is what it is thanks to the following people:
 
 - Sam Foster - Creator, primary developer
-- Tom McKeesick - Performnace enhancements, documentation formatting
+- Tom McKeesick - Performance enhancements, documentation formatting
 - Alex Myczko - Man page, Debian ambassador
 - sigurdo - Cursor shapes, command-line ANSI export
 - yumpyy - Dockerfile
@@ -641,4 +641,3 @@ Durdraw is Copyright (c) 2009-2025 Sam Foster <samfoster@gmail.com>. All rights 
 The BSD Daemon is Copyright 1988 by Marshall Kirk McKusick.
 
 This software is distributed under the BSD 3-Clause License. See LICENSE file for details.
-

--- a/durdraw/durdraw_ansiparse.py
+++ b/durdraw/durdraw_ansiparse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3 
+#!/usr/bin/env python3
 
 # Theory of operation notes:
 # A code starts with '\x1B[' or ^[ and ends with a LETTER.
@@ -62,7 +62,7 @@ color_name_to_durcolor_table = {
     'Magenta': 6,
     'Cyan': 4,
     'White': 8,
-    
+
     'Black': 00,
     'Red': 00,
     'Green': 00,
@@ -150,7 +150,7 @@ def get_width_and_height_of_ansi_blob(text, width=80):
                 if len(escape_sequence) == 0:
                     escape_sequence = '0'   # default - clear from cursor to end
                 if escape_sequence == '2':  # cls, move to top left
-                    # using a sledgehammer to claer the screen
+                    # using a sledgehammer to clear the screen
                     #new_frame = durmovie.Frame(width, height + 1)
                     col_num, line_num = 0, 0
                 i = end_index + 1   # move on to next byte
@@ -173,7 +173,7 @@ def get_width_and_height_of_ansi_blob(text, width=80):
             pass    # pfft
         elif text[i:i + 5] == 'SAUCE' and len(text) - i == 128:   # SAUCE record found
             i += 128
-            # Wee, I'm flying
+            # Whee, I'm flying
         else:   # printable character (hopefully)
             if col_num == width:
                 col_num = 0
@@ -188,7 +188,7 @@ def get_width_and_height_of_ansi_blob(text, width=80):
     return width, height
 
 def parse_ansi_escape_codes(text, filename = None, appState=None, caller=None, console=False, debug=False, convert_control_codes=True, maxWidth=80):
-    """ Take an ANSI file blob, load it into a DUR frame object, return 
+    """ Take an ANSI file blob, load it into a DUR frame object, return
         frame """
     sauce = None
 
@@ -302,11 +302,11 @@ def parse_ansi_escape_codes(text, filename = None, appState=None, caller=None, c
                             code += 60  # 30 -> 90, etc, for DOS-style bright colors that use bold
                             #bold = False
                         if appState.colorMode == "256":
-                            fg_color = dur_ansilib.ansi_code_to_dur_16_color[str(code)] 
+                            fg_color = dur_ansilib.ansi_code_to_dur_16_color[str(code)]
                         else:
                             #if bold:
                             #    code += 60  # 30 -> 90, etc, for DOS-style bright colors that use bold
-                            fg_color = dur_ansilib.ansi_code_to_dur_16_color[str(code)] 
+                            fg_color = dur_ansilib.ansi_code_to_dur_16_color[str(code)]
                             #if bold:
                             #    fg_color += 8
                         # fix for durdraw color pair stupidity
@@ -341,14 +341,14 @@ def parse_ansi_escape_codes(text, filename = None, appState=None, caller=None, c
                         else:
                             fg_color = 1
                     # 256 Colors
-                #if console:    
+                #if console:
                 #    print(str(escape_codes), end="")
 
                 # Add color to color map
                 try:
                     new_frame.newColorMap[line_num][col_num] = [fg_color, bg_color]
                 except Exception as E:
-                    if console:    
+                    if console:
                         print(str(E))
                         print(f"line num: {line_num}")
                 i = end_index + 1
@@ -411,7 +411,7 @@ def parse_ansi_escape_codes(text, filename = None, appState=None, caller=None, c
                 if len(escape_sequence) == 0:
                     escape_sequence = '0'   # default - clear from cursor to end
                 if escape_sequence == '2':  # cls, move to top left
-                    # using a sledgehammer to claer the screen
+                    # using a sledgehammer to clear the screen
                     new_frame = durmovie.Frame(width, height + 1)
                     col_num, line_num = 0, 0
                 i = end_index + 1   # move on to next byte
@@ -476,11 +476,11 @@ def parse_ansi_escape_codes(text, filename = None, appState=None, caller=None, c
                 parse_error = True
                 if debug:
                     caller.notify(f"Error writing color. Width: {width}, Height: {height}, line: {line_num}, col: {col_num}, pos: {i}")
-           # if console:    
+           # if console:
            #     print(character, end='')
             col_num += 1
         i += 1
-    if console:    
+    if console:
         print("")
         print(f"Lines: {line_num}, Columns: {max_col}")
     if parse_error and appState.debug:
@@ -517,5 +517,3 @@ if __name__ == "__main__":
         print(str(newFrame))
         #print(parsed_text)
         #print(f"Fg: {fg}, bg: {bg}")
-
-

--- a/durdraw/durdraw_appstate.py
+++ b/durdraw/durdraw_appstate.py
@@ -7,7 +7,7 @@ import pickle
 import subprocess
 import sys
 import threading
-from sys import version_info 
+from sys import version_info
 from durdraw.durdraw_options import Options
 import durdraw.durdraw_file as durfile
 import durdraw.durdraw_sauce as dursauce
@@ -31,11 +31,11 @@ class AppState():
         self.stop_event = threading.Event()
         self.bg_download_thread = None
         self.bg_download_executor = None
-        # String containnig updates from threads to tell users about
-        self.thread_update_string = None 
+        # String containing updates from threads to tell users about
+        self.thread_update_string = None
         self.pool_executor = None
 
-        # User friendly defeaults
+        # User friendly defaults
         self.quickStart = False
         self.mental = False # Mental mode - enable experimental options/features
         self.showStartupScreen = False
@@ -48,10 +48,10 @@ class AppState():
         self.maxColors = 256
         self.iceColors = False
 
-        # 16c stuff 
+        # 16c stuff
         self.sixteenc_available = True # Enabled if 16colo.rs browsing is available
         self.sixteenc_browsing = False   # Enabled if we are currently browsing 16c
-        self.sixteenc_dizcache = {} # {"packname": dizdata} 
+        self.sixteenc_dizcache = {} # {"packname": dizdata}
         self.sixteenc_cached_years = [] # [1996, etc]
         self.sixteenc_api = None
         self.sixteenc_year = None
@@ -154,8 +154,8 @@ class AppState():
         self.sideBar_minimum_width_256 = 37 # Must have this much width to draw sidebar. Actually it's the colorBar width.
         self.sideBar_minimum_width_16 = 12 # Must have this much width to draw sidebar. Actually it's the colorBar width.
         self.bottomBar_minimum_height = 10  # same as above, but for height
-        self.bottomBar_minimum_height_256 = 10 
-        self.bottomBar_minimum_height_16 = 4 
+        self.bottomBar_minimum_height_256 = 10
+        self.bottomBar_minimum_height_16 = 4
         self.colorBar_height = 8
         self.sideBarShowing = False
         self.themesEnabled = True
@@ -255,13 +255,13 @@ class AppState():
 
     def loadThemeList(self):
         """ Look for theme files in internal durdraw directory """
-        # durhelp256_fullpath = pathlib.Path(__file__).parent.joinpath("help/durhelp-256-long.dur") 
+        # durhelp256_fullpath = pathlib.Path(__file__).parent.joinpath("help/durhelp-256-long.dur")
         # Get a list of files from the themes paths
         internal_theme_path = pathlib.Path(__file__).parent.joinpath("themes/")
         self.internal_theme_file_list = glob.glob(f"{internal_theme_path}/*.dtheme.ini")
         #user_theme_path = pathlib.Path(__file__).parent.joinpath("themes/")
         #self.user_theme_file_list = glob.glob(f"{user_theme_path}/*.dtheme.ini")
-        # Turn lists into an index of Theme name, Theme type, and Path to 
+        # Turn lists into an index of Theme name, Theme type, and Path to
         theme_files = []   # populate with a list of dicts containing name=, path=, type=
         for filename in self.internal_theme_file_list:
             theme_files += filename
@@ -275,7 +275,7 @@ class AppState():
         readConfigPaths = configFile.read(configFileLocations)
         if self.configFile == []:
             self.configFileLoaded = False
-            return False 
+            return False
         else:
             self.configFileName = readConfigPaths
             self.configFile = configFile
@@ -432,6 +432,3 @@ class AppState():
         #    self.hasHelpFile = False
         #    self.helpMov = None
         #    return False
-
-
-

--- a/durdraw/durdraw_charsets.py
+++ b/durdraw/durdraw_charsets.py
@@ -1,4 +1,4 @@
-# Load character sets from files, initialize them 
+# Load character sets from files, initialize them
 
 import configparser
 import pdb
@@ -26,7 +26,7 @@ def hex_range_iterator(start_hex, end_hex):
         current_int += 1
 
 def parse_xml_blocks_file(xml_file_path):
-    """ laod XML file, returns block_data object, containing all the block
+    """ load XML file, returns block_data object, containing all the block
         names and their first and last code point (hex value)
      """
     block_data = {}
@@ -40,7 +40,7 @@ def parse_xml_blocks_file(xml_file_path):
         first_cp = block_element.get('first-cp')
         last_cp = block_element.get('last-cp')
         block_name = block_element.get('name')
-        
+
         if block_name is not None and first_cp is not None and last_cp is not None:
             block_data[block_name] = {
                 'first-cp': first_cp,
@@ -48,7 +48,7 @@ def parse_xml_blocks_file(xml_file_path):
             }
     return block_data
 
-# We can return a fullCharMap that looks like this: [ {'f1':\x1FB00, 
+# We can return a fullCharMap that looks like this: [ {'f1':\x1FB00,
 # 895         self.fullCharMap = [ \
 # 896             # All of our unicode templates live here. Blank template:
 # 897             #{'f1':, 'f2':, 'f3':, 'f4':, 'f5':, 'f6':, 'f7':, 'f8':, 'f9':, 'f10':},
@@ -159,7 +159,7 @@ def load_charmap_file(file_path: str, appState, setting=False):
             charMap.append(fKeyList.copy())
 
             blockNum += 1
-        else:   
+        else:
             # ran out of blocks. Stop searching.
             scanning = False
 

--- a/durdraw/durdraw_color_curses.py
+++ b/durdraw/durdraw_color_curses.py
@@ -113,7 +113,7 @@ mirc_16_to_color_16 = {
     8: 15,  # br yellow
     #0: 16, # br white
 }
-    
+
 
 color_16_to_mirc_16 = {
     0: 0, # white
@@ -317,7 +317,7 @@ class AnsiArtStuff():
         pass
 
     def convert_colormap(self, mov, conv_table):
-        """ takes a dictionary that contains a coler mapper. 
+        """ takes a dictionary that contains a coler mapper.
             Modifies the movie
          """    # It might be better to deepclone and return a new movie...
         for frame in mov.frames:
@@ -333,7 +333,7 @@ class AnsiArtStuff():
                     #if pair[1] in conv_table.keys():
                     #    pair[1] = conv_table[pair[1]]
 
-        
+
     def initColorPairs_general(self, fg_count=256, bg_count=16, use_order=False):   # High color pairs, 256 color
         """ Initialize 256 color mode color pairs """
         self.colorPairMap = {}
@@ -444,7 +444,7 @@ class AnsiArtStuff():
             #self.colorPairMap.update({(curses.COLOR_YELLOW,bg):7})
             #curses.init_pair(7, curses.COLOR_WHITE, bg) # white - 7 (and 0)
             #self.colorPairMap.update({(curses.COLOR_WHITE,bg):8})
-            
+
 
             # basic ncurses colors - comments for these are durdraw internal color numbers:
             curses.init_pair(0, curses.COLOR_BLACK, defaultBg) # black - 0
@@ -462,7 +462,7 @@ class AnsiArtStuff():
                 }
 
 
-            # redo it fro scrarch:
+            # redo it from scratch:
             pair = 0
             #bg += 1
             bg = 0
@@ -600,7 +600,7 @@ class AnsiArtStuff():
         curses.init_pair(64, curses.COLOR_WHITE, curses.COLOR_WHITE)   # 8,7
         #curses.init_pair(64, defaultBg, curses.COLOR_RED)   # 8,7
         # ^ this doesn't work ?!@ ncurses pair # must be between 1 and 63
-        # or ncurses (const?) COLOR_PAIR - 1 
+        # or ncurses (const?) COLOR_PAIR - 1
         # fix is: have functions to swap color map from blackfg to normal.
         # call that function when drawing if the fg color == black, then switch back
         # after each character. Or.. keep track which map we're in in a variable.
@@ -609,9 +609,9 @@ class AnsiArtStuff():
              (0,0):1, (1,0):1, (2,0):2, (3,0):3, (4,0):4, (5,0):5, (6,0):6, (7,0):7, (8,0):8,
              # and again, because black == both 0 and 8. :| let's just ditch 0?
              (0,8):1, (1,8):1, (2,8):2, (3,8):3, (4,8):4, (5,8):5, (6,8):6, (7,8):7, (8,8):8,
-             # white with backround colors 
+             # white with background colors
              (1,1):9, (1,2):10, (1,3):11, (1,4):12, (1,5):13, (1,6):14, (1,7):15,
-             # cyan with backround colors 
+             # cyan with background colors
              (2,1):16, (2,2):17, (2,3):18, (2,4):19, (2,5):20, (2,6):21, (2,7):22,
              # magenta with background colors
              (3,1):23, (3,2):24, (3,3):25, (3,4):26, (3,5):27, (3,6):28, (3,7):29,
@@ -624,17 +624,17 @@ class AnsiArtStuff():
              # red with background colors
              (7,1):51, (7,2):52, (7,3):53, (7,4):54, (7,5):55, (7,6):56, (7,7):57,
              # black with background colors
-             (8,1):58, (8,2):59, (8,3):60, (8,4):61, (8,5):62, (8,6):63, 
+             (8,1):58, (8,2):59, (8,3):60, (8,4):61, (8,5):62, (8,6):63,
              #(8,7):57,  # 57 instead of 64, because we switch color maps for black
              # on red
-             (8,7):64, 
+             (8,7):64,
              # Again, this time with feeling
-             (0,1):58, (0,2):59, (0,3):60, (0,4):61, (0,5):62, (0,6):63, 
-             (0,7):57,  
+             (0,1):58, (0,2):59, (0,3):60, (0,4):61, (0,5):62, (0,6):63,
+             (0,7):57,
              # BRIGHT COLORS 9-16
-             # white with backround colors 
+             # white with background colors
              (9,0):1, (9,8):1, (9,1):9, (9,2):10, (9,3):11, (9,4):12, (9,5):13, (9,6):14, (9,7):15,
-             # cyan with backround colors 
+             # cyan with background colors
              (10,0):2, (10,8):2, (10,1):16, (10,2):17, (10,3):18, (10,4):19, (10,5):20, (10,6):21, (10,7):22,
              # magenta with background colors
              (11,0):3, (11,8):3, (11,1):23, (11,2):24, (11,3):25, (11,4):26, (11,5):27, (11,6):28, (11,7):29,
@@ -647,9 +647,9 @@ class AnsiArtStuff():
              # red with background colors
              (15,0):7, (15,8):7, (15,1):51, (15,2):52, (15,3):53, (15,4):54, (15,5):55, (15,6):56, (15,7):57,
              # black with background colors
-             (16,0):8, (16,8):8, (16,1):58, (16,2):59, (16,3):60, (16,4):61, (16,5):62, (16,6):63, 
+             (16,0):8, (16,8):8, (16,1):58, (16,2):59, (16,3):60, (16,4):61, (16,5):62, (16,6):63,
              #(16,7):57,  # 57 instead of 64, because we switch color maps for black
-             (16,7):64,  
+             (16,7):64,
              } # (fg,bg):cursespair
 
     def initColorPairs_cga_old(self):
@@ -730,7 +730,7 @@ class AnsiArtStuff():
        curses.init_pair(57, curses.COLOR_BLACK, curses.COLOR_RED)   # 8,7
        #curses.init_pair(64, curses.COLOR_BLACK, curses.COLOR_RED)   # 8,7
        # ^ this doesn't work ?!@ ncurses pair # must be between 1 and 63
-       # or ncurses (const?) COLOR_PAIR - 1 
+       # or ncurses (const?) COLOR_PAIR - 1
        # fix is: have functions to swap color map from blackfg to normal.
        # call that function when drawing if the fg color == black, then switch back
        # after each character. Or.. keep track which map we're in in a variable.
@@ -739,9 +739,9 @@ class AnsiArtStuff():
             (0,0):1, (1,0):1, (2,0):2, (3,0):3, (4,0):4, (5,0):5, (6,0):6, (7,0):7, (8,0):8,
             # and again, because black == both 0 and 8. :| let's just ditch 0?
             (0,8):1, (1,8):1, (2,8):2, (3,8):3, (4,8):4, (5,8):5, (6,8):6, (7,8):7, (8,8):8,
-            # white with backround colors 
+            # white with background colors
             (1,1):9, (1,2):10, (1,3):11, (1,4):12, (1,5):13, (1,6):14, (1,7):15,
-            # cyan with backround colors 
+            # cyan with background colors
             (2,1):16, (2,2):17, (2,3):18, (2,4):19, (2,5):20, (2,6):21, (2,7):22,
             # magenta with background colors
             (3,1):23, (3,2):24, (3,3):25, (3,4):26, (3,5):27, (3,6):28, (3,7):29,
@@ -754,13 +754,13 @@ class AnsiArtStuff():
             # red with background colors
             (7,1):51, (7,2):52, (7,3):53, (7,4):54, (7,5):55, (7,6):56, (7,7):57,
             # black with background colors
-            (8,1):58, (8,2):59, (8,3):60, (8,4):61, (8,5):62, (8,6):63, 
+            (8,1):58, (8,2):59, (8,3):60, (8,4):61, (8,5):62, (8,6):63,
             (8,7):57,  # 57 instead of 64, because we switch color maps for black
             # on red
             # BRIGHT COLORS 9-16
-            # white with backround colors 
+            # white with background colors
             (9,0):1, (9,8):1, (9,1):9, (9,2):10, (9,3):11, (9,4):12, (9,5):13, (9,6):14, (9,7):15,
-            # cyan with backround colors 
+            # cyan with background colors
             (10,0):2, (10,8):2, (10,1):16, (10,2):17, (10,3):18, (10,4):19, (10,5):20, (10,6):21, (10,7):22,
             # magenta with background colors
             (11,0):3, (11,8):3, (11,1):23, (11,2):24, (11,3):25, (11,4):26, (11,5):27, (11,6):28, (11,7):29,
@@ -773,7 +773,7 @@ class AnsiArtStuff():
             # red with background colors
             (15,0):7, (15,8):7, (15,1):51, (15,2):52, (15,3):53, (15,4):54, (15,5):55, (15,6):56, (15,7):57,
             # black with background colors
-            (16,0):8, (16,8):8, (16,1):58, (16,2):59, (16,3):60, (16,4):61, (16,5):62, (16,6):63, 
+            (16,0):8, (16,8):8, (16,1):58, (16,2):59, (16,3):60, (16,4):61, (16,5):62, (16,6):63,
             (16,7):57,  # 57 instead of 64, because we switch color maps for black
             } # (fg,bg):cursespair
 
@@ -867,9 +867,9 @@ class AnsiArtStuff():
             (0,0):1, (1,0):1, (2,0):2, (3,0):3, (4,0):4, (5,0):5, (6,0):6, (7,0):7, (8,0):8,
             # and again, because black == both 0 and 8. :| let's just ditch 0?
             (0,8):1, (1,8):1, (2,8):2, (3,8):3, (4,8):4, (5,8):5, (6,8):6, (7,8):7, (8,8):8,
-            # white with backround colors
+            # white with background colors
             (1,1):9, (1,2):10, (1,3):11, (1,4):12, (1,5):13, (1,6):14, (1,7):15,
-            # cyan with backround colors
+            # cyan with background colors
             (2,1):16, (2,2):17, (2,3):18, (2,4):19, (2,5):20, (2,6):21, (2,7):22,
             # magenta with background colors
             (3,1):23, (3,2):24, (3,3):25, (3,4):26, (3,5):27, (3,6):28, (3,7):29,
@@ -886,7 +886,7 @@ class AnsiArtStuff():
             (8,7):57,  # 57 instead of 64, because we switch color maps for black
             # on red
             # BRIGHT COLORS 9-16
-            # white with backround colors
+            # white with background colors
             (9,0):1, (9,8):1, (9,1):9, (9,2):10, (9,3):11, (9,4):12, (9,5):13, (9,6):14, (9,7):15,
             # cyan with backround colors
             (10,0):2, (10,8):2, (10,1):16, (10,2):17, (10,3):18, (10,4):19, (10,5):20, (10,6):21, (10,7):22,
@@ -904,5 +904,3 @@ class AnsiArtStuff():
             (16,0):8, (16,8):8, (16,1):58, (16,2):59, (16,3):60, (16,4):61, (16,5):62, (16,6):63,
             (16,7):57,  # 57 instead of 64, because we switch color maps for black
             } # (fg,bg):cursespair
-
-

--- a/durformat.md
+++ b/durformat.md
@@ -8,7 +8,7 @@ Durdraw files store color text art (both animated and static) in a file format w
 
 The "contents" array contains strings, each one of which represents a line of ASCII or Utf-8 text in a frame of art. This can be thought of as a flat ASCII (or Unicode) art file which has been separated into lines, with each line stored as a string in the array.
 
-Similarly, colorMap contains an array of lines, wich each line containing a list of foreground and background color pairs. For example, the pair [1,0] represents blue text with a black background.
+Similarly, colorMap contains an array of lines, which each line containing a list of foreground and background color pairs. For example, the pair [1,0] represents blue text with a black background.
 
 Each element of the colorMap should coordinate with a corresponding line and column in the contents. For example, colorMap[2][3] should describe the foreground and background color for the character at contents[2][3], which is the character at Line 2, Column 3 of the given frame.
 


### PR DESCRIPTION
Author: rezky_nightky <with dot rezky at gmail dot com>
Repository: durdraw
Branch: master
Signing: GPG (989AF9F0)
HashAlgo: BLAKE3

[ Block Metadata ]
BlockHash: f9c24cd5208e53d09878a7ef8fd77086463cc7de9eaada51a4c623b446b66760 PrevHash: 06e497c4669b3fed8929239880493ce2ee0aa9ba38752bb903e6494c3b95cf66 PatchHash: d09c3410aa1e3543021c2183693fa9554a00a0ccd480eb9f2b7fff96074ed46a

FilesChanged: 6
Lines: +61 / -69

Timestamp: 2025-12-12T10:07:54Z
Signature1: 6ac7940fadadab5ed489e4a2947c61fd88197c945d7041c4b2c51605c6dc4aec
Signature2: cb74bea05a3a234ece3a691830d0d6a0142c958654f0ed11cfc9fc26b09065d2